### PR TITLE
New structure to properly hold [source => input => (output=value)]. Needed to compute multi-sources projects.

### DIFF
--- a/include/emergy.h
+++ b/include/emergy.h
@@ -48,6 +48,7 @@ namespace tudor_emergy {
 	double flowLostToLoops;
 	double totalInputFlow;      /// total quantity of emergy when starting the computation
 	double totalOutputFlow;     /// total quantity of emergy at the output after computation
+	EmNodeSet visitedNodes;     /// Set of nodes that have been visited at least once
 	EmPathLists allPaths;		/// only populate this if requested in EmParams
 	EmNodeValueMap outputFlows;
 	EmGraphMap inputOutputFlows; /// [input => (output=value)]

--- a/include/emergy.h
+++ b/include/emergy.h
@@ -46,6 +46,8 @@ namespace tudor_emergy {
 	size_t pathLoopCount;
 	double flowLostToMinflow;
 	double flowLostToLoops;
+	double totalInputFlow;      /// total quantity of emergy when starting the computation
+	double totalOutputFlow;     /// total quantity of emergy at the output after computation
 	EmPathLists allPaths;		/// only populate this if requested in EmParams
 	EmNodeValueMap outputFlows;
 	EmGraphMap inputOutputFlows; /// [input => (output=value)]

--- a/include/emergy.h
+++ b/include/emergy.h
@@ -28,6 +28,9 @@ namespace tudor_emergy {
   typedef map<string, EmNodeValueMap> EmGraphMap;
   typedef EmGraphMap::const_iterator EGM_cit;
   typedef pair<string, EmNodeValueMap> EmGraphMapEntry;
+  typedef map<string, EmGraphMap> EmSourceInputOutputMap;
+  typedef EmSourceInputOutputMap::const_iterator ESIOM_cit;
+  typedef pair<string, EmGraphMap> EmSourceInputOutputMapEntry;
   typedef set<string> EmNodeSet;
   typedef list<string> EmNodeList;
   typedef list<EmNodeList> EmPathLists;
@@ -46,6 +49,8 @@ namespace tudor_emergy {
 	EmPathLists allPaths;		/// only populate this if requested in EmParams
 	EmNodeValueMap outputFlows;
 	EmGraphMap inputOutputFlows; /// [input => (output=value)]
+  EmSourceInputOutputMap sourceInputOutputFlows; /// [source => input => (output=value)]
+  EmGraphMap sourceOutputFlows; /// [source => (output=value)]
 	EmCalcProfile();
   };
 
@@ -55,11 +60,12 @@ namespace tudor_emergy {
   /// child nodes
   struct EmParams {
 	bool savePaths;				// should all the paths be saved?
-	bool printSources;			// should sources be printed for each output?
+	bool printSources;         // should outputs be printed for each source?
+  bool printInputs;          // should outputs be printed for each input?
 	double minBranchFlow;
 	EmGraphMap sourceInputFlows; /// [source => (input=value)]
 	EmNodeValueMap inputFlows;
-	EmParams() : savePaths(false), printSources(false), minBranchFlow(0.0) { /* empty */ }
+	EmParams() : savePaths(false), printSources(false), printInputs(false), minBranchFlow(0.0) { /* empty */ }
   };
 
   /// calculate the emergy of a system in graph and populate a run profile

--- a/include/emergy.h
+++ b/include/emergy.h
@@ -68,7 +68,7 @@ namespace tudor_emergy {
 	double minBranchFlow;
 	EmGraphMap sourceInputFlows; /// [source => (input=value)]
 	EmNodeValueMap inputFlows;
-	EmParams() : savePaths(false), printSources(false), printInputs(false), minBranchFlow(0.0) { /* empty */ }
+	EmParams() : savePaths(false), printSources(false), printInputs(false), minBranchFlow(0.1) { /* empty */ }
   };
 
   /// calculate the emergy of a system in graph and populate a run profile

--- a/src/calc_emergy.cc
+++ b/src/calc_emergy.cc
@@ -55,12 +55,14 @@ int main(int argc, char **argv) {
   calculateEmergy(graph, params, profile);
 
   // dump number of paths examined
+  std::cout << "total input Flow: " << profile.totalInputFlow << std::endl;
   std::cout << "longest path: " << profile.maxBranchFlows << std::endl;
   std::cout << "complete paths: " << profile.pathCount << std::endl;
   std::cout << "loop violations: " << profile.pathLoopCount << std::endl;
   std::cout << "flow lost to loop violations: " << profile.flowLostToLoops << std::endl;
   std::cout << "minflow violations: " << profile.pathMinflowCount << std::endl;
   std::cout << "flow lost to minflow violations: " << profile.flowLostToMinflow << std::endl;
+  std::cout << "total output flow: " << profile.totalOutputFlow << std::endl;
 
   // dump outputs
   for (ENVM_cit dcit = profile.outputFlows.begin(); dcit != profile.outputFlows.end(); dcit++)

--- a/src/calc_emergy.cc
+++ b/src/calc_emergy.cc
@@ -62,6 +62,7 @@ int main(int argc, char **argv) {
   std::cout << "flow lost to loop violations: " << profile.flowLostToLoops << std::endl;
   std::cout << "minflow violations: " << profile.pathMinflowCount << std::endl;
   std::cout << "flow lost to minflow violations: " << profile.flowLostToMinflow << std::endl;
+  std::cout << "number of visited nodes: " << profile.visitedNodes.size() << std::endl;
   std::cout << "total output flow: " << profile.totalOutputFlow << std::endl;
 
   // dump outputs

--- a/src/emergy.cc
+++ b/src/emergy.cc
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <sstream>
 #include <cassert>
+#include <cstdlib>
 
 #include "emergy.h"
 

--- a/src/emergy.cc
+++ b/src/emergy.cc
@@ -116,6 +116,7 @@ namespace tudor_emergy {
   /// legacy implementation only @TODO replace with non-recursive version
   /// \note pathlist is *NOT* a reference and is passed by value
   void pathBuild(const string& node, const EmGraphMap& g, EmNodeSet& pathset, EmNodeValueMap& outputs, double flow, EmNodeList pathlist, double minflow, EmCalcProfile& profile, const EmParams& params) {
+	profile.visitedNodes.insert(node);
 	if (g.find(node) == g.end()) { // no child so aggregate flow
 	  outputs[node] += flow;
 	  if (pathset.size() > profile.maxBranchFlows)

--- a/src/emergy.cc
+++ b/src/emergy.cc
@@ -153,7 +153,7 @@ namespace tudor_emergy {
   void calculateEmergyWithSources(const EmGraphMap& graph, const EmParams& params, EmCalcProfile& profile) {
 	// get the sourced inputFlows
 	const EmGraphMap& sourceInputs = params.sourceInputFlows;
-	EmGraphMap& inputOutputs = profile.inputOutputFlows;
+	EmSourceInputOutputMap& sourceInputOutputs = profile.sourceInputOutputFlows;
 	for (EGM_cit scit = sourceInputs.begin(); scit != sourceInputs.end(); scit++) {
 
 	  // process all inputs
@@ -161,22 +161,71 @@ namespace tudor_emergy {
 
 	  EmNodeSet pathSet;
 	  EmNodeList pathList;
+	  EmGraphMap inputOutputMap;
 	  for (ENVM_cit cit = inputs.begin(); cit != inputs.end(); cit++) {
 		EmNodeValueMap outputMap;
 		pathBuild(cit->first, graph, pathSet, outputMap, cit->second, pathList, params.minBranchFlow * cit->second, profile, params);
-		inputOutputs.insert(EmGraphMapEntry(scit->first, outputMap));
+		if(! outputMap.empty()) {
+			inputOutputMap.insert(EmGraphMapEntry(cit->first, outputMap));
+		}
+	  }
+	  if (!inputOutputMap.empty()) {
+	  	sourceInputOutputs.insert(EmSourceInputOutputMapEntry(scit->first,inputOutputMap));
 	  }
 	}
 
-	// now aggregate all the input-output flows
+	// now aggregate all the source-input-output flows
 	EmNodeValueMap& outputs = profile.outputFlows;
-	for (EGM_cit cit = inputOutputs.begin(); cit != inputOutputs.end(); cit++)
-	  for (ENVM_cit mcit = cit->second.begin(); mcit != cit->second.end(); mcit++) {
-		if (outputs.find(mcit->first) == outputs.end())
-		  outputs.insert(*mcit);
-		else
-		  outputs[mcit->first] += mcit->second;
+	for (ESIOM_cit scit = sourceInputOutputs.begin(); scit != sourceInputOutputs.end(); scit++) {
+	  for (EGM_cit icit = scit->second.begin(); icit != scit->second.end(); icit++) {
+	  	for (ENVM_cit ocit = icit->second.begin(); ocit != icit->second.end(); ocit++) {
+	  		if (outputs.find(ocit->first) == outputs.end()) {
+	  			outputs.insert(EmNodeValue(ocit->first,0));
+	  		}
+	  		else {
+	  			outputs[ocit->first] += ocit->second;
+	  		}
+	  	}
 	  }
+	}
+
+	// create source-output flows
+	EmGraphMap& sourceOutputs = profile.sourceOutputFlows;
+	for (ESIOM_cit scit = sourceInputOutputs.begin(); scit != sourceInputOutputs.end(); scit++) {
+		EmNodeValueMap outputs;
+		for (EGM_cit icit = scit->second.begin(); icit != scit->second.end(); icit++) {
+			for (ENVM_cit ocit = icit->second.begin(); ocit != icit->second.end(); ocit++) {
+				if (outputs.find(ocit->first) == outputs.end()) {
+					outputs.insert(EmNodeValue(ocit->first,ocit->second));
+				}
+				else {
+					outputs[ocit->first] += ocit->second;
+				}
+			}
+		}
+		sourceOutputs.insert(EmGraphMapEntry(scit->first, outputs));
+	}
+
+	// create input-output flows
+	EmGraphMap& inputOutputs = profile.inputOutputFlows;
+	for (ESIOM_cit scit = sourceInputOutputs.begin(); scit != sourceInputOutputs.end(); scit++) {
+		for (EGM_cit icit = scit->second.begin(); icit != scit->second.end(); icit++) {
+			if(inputOutputs.find(icit->first) == inputOutputs.end()) {
+				inputOutputs.insert(*icit);
+			}
+			else {
+				EmNodeValueMap& outputs =  inputOutputs[icit->first];
+				for (ENVM_cit ocit = icit->second.begin(); ocit != icit->second.end(); ocit++) {
+					if (outputs.find(ocit->first) == outputs.end()) {
+						outputs.insert(EmNodeValue(ocit->first,ocit->second));
+					}
+					else {
+						outputs[ocit->first] += ocit->second;
+					}
+				}
+			}
+		}
+	}
   }
 
   void calculateEmergy(const EmGraphMap& graph, const EmParams& params, EmCalcProfile& profile) {

--- a/src/emergy.cc
+++ b/src/emergy.cc
@@ -17,7 +17,7 @@
 namespace tudor_emergy {
   const double GRAPH_SUM_MAX = 1.001; // tolerance for graph flow violations
 
-  EmCalcProfile::EmCalcProfile() : pathCount(0), maxBranchFlows(0), pathMinflowCount(0), pathLoopCount(0), flowLostToMinflow(0.0), flowLostToLoops(0.0) {
+  EmCalcProfile::EmCalcProfile() : pathCount(0), maxBranchFlows(0), pathMinflowCount(0), pathLoopCount(0), flowLostToMinflow(0.0), flowLostToLoops(0.0), totalInputFlow(0), totalOutputFlow(0) {
 	/*empty */
   }
 
@@ -164,6 +164,7 @@ namespace tudor_emergy {
 	  EmGraphMap inputOutputMap;
 	  for (ENVM_cit cit = inputs.begin(); cit != inputs.end(); cit++) {
 		EmNodeValueMap outputMap;
+		profile.totalInputFlow += cit->second;
 		pathBuild(cit->first, graph, pathSet, outputMap, cit->second, pathList, params.minBranchFlow * cit->second, profile, params);
 		if(! outputMap.empty()) {
 			inputOutputMap.insert(EmGraphMapEntry(cit->first, outputMap));
@@ -185,6 +186,7 @@ namespace tudor_emergy {
 	  		else {
 	  			outputs[ocit->first] += ocit->second;
 	  		}
+	  		profile.totalOutputFlow += ocit->second;
 	  	}
 	  }
 	}

--- a/src/emergy_calculator.cc
+++ b/src/emergy_calculator.cc
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
   // print out the sources of emergy
   using tudor_emergy::EGM_cit;
   if (params.printSources) {
-	std::cout << std::endl << "OUTPUT BY SOURCE:" << std::endl;
+	std::cout << std::endl << "OUTPUT BY INPUT:" << std::endl;
 	for (EGM_cit cit = profile.inputOutputFlows.begin(); cit != profile.inputOutputFlows.end(); cit++) {
 	  printf("%s", cit->first.c_str());
 	  for (ENVM_cit mcit = cit->second.begin(); mcit != cit->second.end(); mcit++)
@@ -152,6 +152,14 @@ int main(int argc, char **argv) {
 	  printf("\n");
 	}
   }
+  std::cout << std::endl << "OUTPUTS BY SOURCE:" << std::endl;
+  for ( tudor_emergy::EGM_cit cit = profile.sourceOutputFlows.begin(); cit != profile.sourceOutputFlows.end(); cit++) {
+    printf("%s", cit->first.c_str());
+    for (tudor_emergy::ENVM_cit mcit = cit->second.begin(); mcit != cit->second.end(); mcit++)
+        printf("\t%s=%.4f", mcit->first.c_str(), mcit->second);
+    printf("\n");
+  }
+  
 
   exit(0);
 }

--- a/src/emergy_calculator.cc
+++ b/src/emergy_calculator.cc
@@ -117,13 +117,15 @@ int main(int argc, char **argv) {
   calculateEmergyWithSources(graph, params, profile);
 
   // dump number of paths examined
-  std::cout << std::endl << "STATISTICS:" << std::endl;
+  std::cout << "total input Flow: " << profile.totalInputFlow << std::endl;
   std::cout << "longest path: " << profile.maxBranchFlows << std::endl;
   std::cout << "complete paths: " << profile.pathCount << std::endl;
   std::cout << "loop violations: " << profile.pathLoopCount << std::endl;
   std::cout << "flow lost to loop violations: " << profile.flowLostToLoops << std::endl;
   std::cout << "minflow violations: " << profile.pathMinflowCount << std::endl;
   std::cout << "flow lost to minflow violations: " << profile.flowLostToMinflow << std::endl;
+  std::cout << "number of visited nodes: " << profile.visitedNodes.size() << std::endl;
+  std::cout << "total output flow: " << profile.totalOutputFlow << std::endl;
 
   // dump outputs
   std::cout << std::endl << "OUTPUTS:" << std::endl;


### PR DESCRIPTION
Hi Gordon,

In the calculateEmergyWithSources procedure, the inputOutputFlows structure did not allow to store each input/output pair for each source. Already computed inputs (in previous sources) where overwriten by new ones. 

1 )I added  a new data structure [source => input => (output=value)],  similar to the ones you used, to allow  identical inputs to appear in various sources.

2 )Added a  totalInputFlow and totalOutputFlow attributes to the EmProfile struct. These two attributes count the total emergy in the inputs of the system and the total emergy found in the output. 

3) Added another attribute to count nodes that ever get visited. Requested by Benedeto from CRP.

4) Last update is simple include for the project to build on windows. 

Best,
Yoann 
